### PR TITLE
Add versioning of terrain chunks and minor imporvments.

### DIFF
--- a/include/voxen/common/terrain/chunk.hpp
+++ b/include/voxen/common/terrain/chunk.hpp
@@ -5,12 +5,15 @@
 namespace voxen
 {
 
-struct TerrainChunkCreateInfo {
+struct TerrainChunkHeader {
 	int64_t base_x;
 	int64_t base_y;
 	int64_t base_z;
 	uint32_t scale;
+	bool operator == (const TerrainChunkHeader &other) const noexcept;
 };
+
+using TerrainChunkCreateInfo = TerrainChunkHeader;
 
 class TerrainChunk {
 public:
@@ -27,10 +30,9 @@ public:
 	TerrainChunk &operator = (const TerrainChunk &);
 	~TerrainChunk() noexcept;
 
-	int64_t baseX() const noexcept { return m_base_x; }
-	int64_t baseY() const noexcept { return m_base_y; }
-	int64_t baseZ() const noexcept { return m_base_z; }
-	uint32_t scale() const noexcept { return m_scale; }
+	const TerrainChunkHeader& header() const noexcept;
+	uint16_t version() const noexcept;
+	void increaseVersion() noexcept;
 
 	Data &data() noexcept { return m_data; }
 	const Data &data() const noexcept { return m_data; }
@@ -39,11 +41,10 @@ public:
 
 	bool operator == (const TerrainChunk &other) const noexcept;
 private:
-	const int64_t m_base_x;
-	const int64_t m_base_y;
-	const int64_t m_base_z;
-	const uint32_t m_scale;
+	const TerrainChunkHeader m_header;
+	uint32_t m_version;
 	Data m_data;
 };
+
 
 }

--- a/include/voxen/common/terrain/chunk.hpp
+++ b/include/voxen/common/terrain/chunk.hpp
@@ -11,6 +11,7 @@ struct TerrainChunkHeader {
 	int64_t base_z;
 	uint32_t scale;
 	bool operator == (const TerrainChunkHeader &other) const noexcept;
+	uint64_t hash() const noexcept;
 };
 
 using TerrainChunkCreateInfo = TerrainChunkHeader;
@@ -31,13 +32,11 @@ public:
 	~TerrainChunk() noexcept;
 
 	const TerrainChunkHeader& header() const noexcept;
-	uint16_t version() const noexcept;
+	uint32_t version() const noexcept;
 	void increaseVersion() noexcept;
 
 	Data &data() noexcept { return m_data; }
 	const Data &data() const noexcept { return m_data; }
-
-	uint64_t headerHash() const noexcept;
 
 	bool operator == (const TerrainChunk &other) const noexcept;
 private:

--- a/include/voxen/common/terrain/loader.hpp
+++ b/include/voxen/common/terrain/loader.hpp
@@ -4,6 +4,10 @@
 #include <voxen/common/terrain/chunk.hpp>
 #include <voxen/common/terrain/generator.hpp>
 
+#if VOXEN_DEBUG_BUILD == 1
+#include <vector>
+#endif /* VOXEN_DEBUG_BUILD */
+
 namespace voxen
 {
 
@@ -16,6 +20,9 @@ public:
 private:
 	TerrainChunkCache m_cache;
 	TerrainGenerator m_generator;
+#if VOXEN_DEBUG_BUILD == 1
+	std::vector<TerrainChunkHeader> m_loaded_chunks;
+#endif /* VOXEN_DEBUG_BUILD */
 };
 
 }

--- a/include/voxen/common/terrain/loader.hpp
+++ b/include/voxen/common/terrain/loader.hpp
@@ -5,7 +5,8 @@
 #include <voxen/common/terrain/generator.hpp>
 
 #if VOXEN_DEBUG_BUILD == 1
-#include <vector>
+#include <unordered_set>
+#include <functional>
 #endif /* VOXEN_DEBUG_BUILD */
 
 namespace voxen
@@ -21,7 +22,7 @@ private:
 	TerrainChunkCache m_cache;
 	TerrainGenerator m_generator;
 #if VOXEN_DEBUG_BUILD == 1
-	std::vector<TerrainChunkHeader> m_loaded_chunks;
+	std::unordered_set<TerrainChunkHeader, std::function<uint64_t(const TerrainChunkHeader&)>> m_loaded_chunks;
 #endif /* VOXEN_DEBUG_BUILD */
 };
 

--- a/src/client/vulkan/algo/debug_octree.cpp
+++ b/src/client/vulkan/algo/debug_octree.cpp
@@ -64,10 +64,10 @@ void AlgoDebugOctree::executePass(VkCommandBuffer cmd_buffer, const WorldState &
 	auto view_proj_mat = view.cameraMatrix();
 
 	state.walkActiveChunks([&](const voxen::TerrainChunk &chunk) {
-		float base_x = float(chunk.baseX());
-		float base_y = float(chunk.baseY());
-		float base_z = float(chunk.baseZ());
-		float size = float(TerrainChunk::SIZE * chunk.scale());
+		float base_x = float(chunk.header().base_x);
+		float base_y = float(chunk.header().base_y);
+		float base_z = float(chunk.header().base_z);
+		float size = float(TerrainChunk::SIZE * chunk.header().scale);
 		glm::mat4 model_mat = extras::scale_translate(base_x, base_y, base_z, size);
 		glm::mat4 mat = view_proj_mat * model_mat;
 

--- a/src/common/terrain/cache.cpp
+++ b/src/common/terrain/cache.cpp
@@ -32,7 +32,7 @@ bool TerrainChunkCache::tryFill(TerrainChunk &chunk)
 
 void TerrainChunkCache::insert(const TerrainChunk &chunk)
 {
-	const size_t set_id = chunk.headerHash() % m_sets.size();
+	const size_t set_id = chunk.header().hash() % m_sets.size();
 	Set &set = m_sets[set_id];
 
 	size_t empty_pos_in_set = SET_SIZE;
@@ -72,7 +72,7 @@ void TerrainChunkCache::invalidate(const TerrainChunk &chunk) noexcept
 
 std::pair<size_t, size_t> TerrainChunkCache::findSetAndIndex(const TerrainChunk &chunk) const noexcept
 {
-	const size_t set_id = chunk.headerHash() % m_sets.size();
+	const size_t set_id = chunk.header().hash() % m_sets.size();
 	const Set &set = m_sets[set_id];
 
 	for (size_t i = 0; i < SET_SIZE; i++) {

--- a/src/common/terrain/cache.cpp
+++ b/src/common/terrain/cache.cpp
@@ -2,6 +2,7 @@
 
 #include <voxen/util/log.hpp>
 
+#include <cassert>
 #include <algorithm>
 
 namespace voxen
@@ -42,7 +43,11 @@ void TerrainChunkCache::insert(const TerrainChunk &chunk)
 			continue;
 		}
 		if (*entry.chunk == chunk) {
-			// This chunk is already in the cache
+			assert(entry.chunk->version() <= chunk.version());
+			// This chunk is already in the cache, but the content can be different
+			if (entry.chunk->version() < chunk.version())
+				// Update voxel data in cache
+				*entry.chunk = chunk;
 			return;
 		}
 	}

--- a/src/common/terrain/chunk.cpp
+++ b/src/common/terrain/chunk.cpp
@@ -13,6 +13,31 @@ bool TerrainChunkHeader::operator== (const TerrainChunkHeader &other) const noex
 	return base_x == other.base_x && base_y == other.base_y && base_z == other.base_z && scale == other.scale;
 }
 
+uint64_t TerrainChunkHeader::hash() const noexcept
+{
+#pragma pack(push, 1)
+	union {
+		struct {
+			uint64_t u64[3];
+			uint32_t u32;
+		} data;
+		uint8_t bytes[sizeof(data)];
+	} conv;
+#pragma pack(pop)
+
+	conv.data.u64[0] = static_cast<uint64_t>(base_x);
+	conv.data.u64[1] = static_cast<uint64_t>(base_y);
+	conv.data.u64[2] = static_cast<uint64_t>(base_z);
+	conv.data.u32 = (scale);
+	// FNV-1a
+	uint64_t result = 0xCBF29CE484222325;
+	for (size_t i = 0; i < std::size(conv.bytes); i++) {
+		result *= 0x100000001B3;
+		result ^= uint64_t(conv.bytes[i]);
+	}
+	return result;
+}
+
 TerrainChunk::TerrainChunk(const TerrainChunkCreateInfo &info)
 	: m_header(info), m_version(0U)
 {
@@ -44,31 +69,6 @@ TerrainChunk::~TerrainChunk() noexcept
 {
 }
 
-uint64_t TerrainChunk::headerHash() const noexcept
-{
-#pragma pack(push, 1)
-	union {
-		struct {
-			uint64_t u64[3];
-			uint32_t u32;
-		} data;
-		uint8_t bytes[sizeof(data)];
-	} conv;
-#pragma pack(pop)
-
-	conv.data.u64[0] = static_cast<uint64_t>(m_header.base_x);
-	conv.data.u64[1] = static_cast<uint64_t>(m_header.base_y);
-	conv.data.u64[2] = static_cast<uint64_t>(m_header.base_z);
-	conv.data.u32 = (m_header.scale);
-	// FNV-1a
-	uint64_t result = 0xCBF29CE484222325;
-	for (size_t i = 0; i < std::size(conv.bytes); i++) {
-		result *= 0x100000001B3;
-		result ^= uint64_t(conv.bytes[i]);
-	}
-	return result;
-}
-
 bool TerrainChunk::operator == (const TerrainChunk &other) const noexcept
 {
 	return m_header == other.m_header;
@@ -78,7 +78,7 @@ const TerrainChunkHeader& TerrainChunk::header() const noexcept {
 	return m_header;
 }
 
-uint16_t TerrainChunk::version() const noexcept {
+uint32_t TerrainChunk::version() const noexcept {
 	return m_version;
 }
 void TerrainChunk::increaseVersion() noexcept {

--- a/src/common/terrain/generator.cpp
+++ b/src/common/terrain/generator.cpp
@@ -9,18 +9,20 @@ namespace voxen
 
 void TerrainGenerator::generate(TerrainChunk &chunk)
 {
-	Log::trace("Generating chunk at ({}, {}, {})(x{})", chunk.baseX(), chunk.baseY(), chunk.baseZ(), chunk.scale());
+	const TerrainChunkHeader& header = chunk.header();
+
+	Log::trace("Generating chunk at ({}, {}, {})(x{})", header.base_x, header.base_y, header.base_z, header.scale);
 	auto &output = chunk.data().voxel_id;
 
-	const uint32_t step = chunk.scale();
+	const uint32_t step = header.scale;
 
 	// TODO: this is a temporary stub, add real land generator
 	for (uint32_t i = 0; i <= TerrainChunk::SIZE; i++) {
-		int64_t y = chunk.baseY() + i * step;
+		int64_t y = header.base_y + i * step;
 		for (uint32_t j = 0; j <= TerrainChunk::SIZE; j++) {
-			int64_t x = chunk.baseX() + j * step;
+			int64_t x = header.base_x + j * step;
 			for (uint32_t k = 0; k <= TerrainChunk::SIZE; k++) {
-				int64_t z = chunk.baseZ() + k * step;
+				int64_t z = header.base_z + k * step;
 
 				uint8_t voxel = 0;
 				if (y <= 0 || std::abs(x) > 100 || std::abs(z) > 100)

--- a/src/common/terrain/loader.cpp
+++ b/src/common/terrain/loader.cpp
@@ -1,5 +1,10 @@
 #include <voxen/common/terrain/loader.hpp>
 
+#if VOXEN_DEBUG_BUILD == 1
+#include <cassert>
+#include <algorithm>
+#endif /* VOXEN_DEBUG_BUILD */
+
 namespace voxen
 {
 
@@ -16,12 +21,31 @@ void TerrainLoader::load(TerrainChunk &chunk)
 	// TODO: support loading from disk
 	m_generator.generate(chunk);
 	m_cache.insert(chunk);
+
+#if VOXEN_DEBUG_BUILD == 1
+	TerrainChunkHeader header = chunk.header();
+	auto search = std::find(m_loaded_chunks.begin(), m_loaded_chunks.end(), header);
+	// We mustn't load already loaded chunk
+	assert(search == m_loaded_chunks.end());
+	m_loaded_chunks.push_back(header);
+#endif /* VOXEN_DEBUG_BUILD */
 }
 
 void TerrainLoader::unload(TerrainChunk &chunk)
 {
 	// TODO: support saving to disk
+
+	// insert will update chunk data, if the chunk still in cache
+	// or insert again, if the cache already flush the chunk
+	m_cache.insert(chunk);
 	(void) chunk;
+#if VOXEN_DEBUG_BUILD == 1
+	TerrainChunkHeader header = chunk.header();
+	auto search = std::find(m_loaded_chunks.begin(), m_loaded_chunks.end(), header);
+	// We mustn't unload not loaded yet chunk
+	assert(search != m_loaded_chunks.end());
+	m_loaded_chunks.erase(search);
+#endif /* VOXEN_DEBUG_BUILD */
 }
 
 }

--- a/src/common/terrain/loader.cpp
+++ b/src/common/terrain/loader.cpp
@@ -2,7 +2,6 @@
 
 #if VOXEN_DEBUG_BUILD == 1
 #include <cassert>
-#include <algorithm>
 #endif /* VOXEN_DEBUG_BUILD */
 
 namespace voxen
@@ -11,41 +10,45 @@ namespace voxen
 static constexpr inline size_t CACHE_SIZE = 65536;
 
 TerrainLoader::TerrainLoader() : m_cache(CACHE_SIZE)
+#if VOXEN_DEBUG_BUILD == 1
+, m_loaded_chunks(0, [](const TerrainChunkHeader& header) {return header.hash();})
+#endif /* VOXEN_DEBUG_BUILD */
 {
 }
 
 void TerrainLoader::load(TerrainChunk &chunk)
 {
+#if VOXEN_DEBUG_BUILD == 1
+	TerrainChunkHeader header = chunk.header();
+	auto search = m_loaded_chunks.find(header);
+	// We mustn't load already loaded chunk
+	assert(search == m_loaded_chunks.end());
+	m_loaded_chunks.insert(header);
+#endif /* VOXEN_DEBUG_BUILD */
+
 	if (m_cache.tryFill(chunk))
 		return;
 	// TODO: support loading from disk
 	m_generator.generate(chunk);
 	m_cache.insert(chunk);
 
-#if VOXEN_DEBUG_BUILD == 1
-	TerrainChunkHeader header = chunk.header();
-	auto search = std::find(m_loaded_chunks.begin(), m_loaded_chunks.end(), header);
-	// We mustn't load already loaded chunk
-	assert(search == m_loaded_chunks.end());
-	m_loaded_chunks.push_back(header);
-#endif /* VOXEN_DEBUG_BUILD */
 }
 
 void TerrainLoader::unload(TerrainChunk &chunk)
 {
-	// TODO: support saving to disk
-
-	// insert will update chunk data, if the chunk still in cache
-	// or insert again, if the cache already flush the chunk
-	m_cache.insert(chunk);
-	(void) chunk;
 #if VOXEN_DEBUG_BUILD == 1
 	TerrainChunkHeader header = chunk.header();
-	auto search = std::find(m_loaded_chunks.begin(), m_loaded_chunks.end(), header);
+	auto search = m_loaded_chunks.find(header);
 	// We mustn't unload not loaded yet chunk
 	assert(search != m_loaded_chunks.end());
 	m_loaded_chunks.erase(search);
 #endif /* VOXEN_DEBUG_BUILD */
+
+	// TODO: support saving to disk
+	// insert will update chunk data, if the chunk still in cache
+	// or insert again, if the cache already flush the chunk
+	m_cache.insert(chunk);
+	(void) chunk;
 }
 
 }


### PR DESCRIPTION
In details:
  - Move chunk header info to separate class TerrainChunkHeader
  - Remove information (and data structure) duplication between TerrainChunkCreateInfo and TerrainChunkHeader
  - Add debug-only code for checking, that we call TerrainLoader::load only for unloaded chunks, and call TerrainLoader::unload only for loaded chunks.