### PR TITLE
Error handling refactor

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -85,6 +85,7 @@ set(VOXEN_HEADERS
 	include/voxen/util/allocator.hpp
 	include/voxen/util/debug.hpp
 	include/voxen/util/elapsed_timer.hpp
+	include/voxen/util/error_condition.hpp
 	include/voxen/util/exception.hpp
 	include/voxen/util/hash.hpp
 	include/voxen/util/log.hpp

--- a/include/extras/source_location.hpp
+++ b/include/extras/source_location.hpp
@@ -35,26 +35,20 @@ consteval size_t findBaseDirOffset(std::string_view str) noexcept
 }
 #endif
 
-// Almost exact copy of `std::source_location` from C++20.
-// Provides consistent behaviour until standard one is properly implemented.
+// Own implementation of `std::source_location` from C++20 (with file/line only).
+// Provides consistent behaviour until standard one is stable and widely available.
 class source_location final {
 public:
 
-#if defined(__has_builtin) && \
-	__has_builtin(__builtin_FILE) && __has_builtin(__builtin_FUNCTION) && \
-	__has_builtin(__builtin_LINE) && __has_builtin(__builtin_COLUMN)
+#if defined(__has_builtin) && __has_builtin(__builtin_FILE) && __has_builtin(__builtin_LINE)
 
 	// GCC/Clang-specific implementation. Not using `std::experimental` one even if it is available.
 	constexpr static source_location current(const char *file = __builtin_FILE(),
-	                                         const char *func = __builtin_FUNCTION(),
-	                                         uint_least32_t line = __builtin_LINE(),
-	                                         uint_least32_t col = __builtin_COLUMN()) noexcept
+	                                         uint_least32_t line = __builtin_LINE()) noexcept
 	{
 		source_location loc;
 		loc.m_file = file + FILE_BASE_DIR_OFFSET;
-		loc.m_func = func;
 		loc.m_line = line;
-		loc.m_col = col;
 		return loc;
 	}
 #else
@@ -64,9 +58,7 @@ public:
 #endif // __has_builtin(*) stuff
 
 	constexpr const char *file_name() const noexcept { return m_file; }
-	constexpr const char *function_name() const noexcept { return m_func; }
 	constexpr uint_least32_t line() const noexcept { return m_line; }
-	constexpr uint_least32_t column() const noexcept { return m_col; }
 
 private:
 #if __clang_major__ < 13
@@ -77,9 +69,7 @@ private:
 #endif
 
 	const char *m_file = "unknown";
-	const char *m_func = "unknown";
 	uint_least32_t m_line = 0;
-	uint_least32_t m_col = 0;
 };
 
 }

--- a/include/voxen/client/vulkan/common.hpp
+++ b/include/voxen/client/vulkan/common.hpp
@@ -40,19 +40,13 @@ public:
 	static uint64_t calcFraction(uint64_t size, uint64_t numerator, uint64_t denomenator) noexcept;
 };
 
-class VulkanException : public Exception {
+class VulkanException final : public Exception {
 public:
-	explicit VulkanException(VkResult result, const char *api = nullptr, extras::source_location loc =
-		extras::source_location::current()) noexcept;
-	virtual ~VulkanException() = default;
+	explicit VulkanException(VkResult result, std::string_view api, extras::source_location loc =
+		extras::source_location::current());
+	~VulkanException() noexcept override;
 
-	virtual const char *what() const noexcept override;
-	VkResult result() const noexcept { return m_result; }
-
-protected:
-	std::string m_message;
-	VkResult m_result;
-	bool m_exception_occured = false;
+	VkResult result() const noexcept;
 };
 
 class HostAllocator {

--- a/include/voxen/client/vulkan/common.hpp
+++ b/include/voxen/client/vulkan/common.hpp
@@ -8,6 +8,19 @@
 #include <atomic>
 #include <string>
 #include <string_view>
+#include <system_error>
+
+namespace std
+{
+
+// Mark `VkResult` as eligible for `std::error_condition`
+template<>
+struct is_error_condition_enum<VkResult> : true_type {};
+
+// Factory for `std::error_condition { VkResult }`
+error_condition make_error_condition(VkResult result) noexcept;
+
+}
 
 namespace voxen::client::vulkan
 {

--- a/include/voxen/client/vulkan/common.hpp
+++ b/include/voxen/client/vulkan/common.hpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <string>
+#include <string_view>
 
 namespace voxen::client::vulkan
 {
@@ -16,9 +17,8 @@ class VulkanUtils final {
 public:
 	VulkanUtils() = delete;
 
-	static const char *getVkResultString(VkResult result) noexcept;
-	static const char *getVkResultDescription(VkResult result) noexcept;
-	static const char *getVkFormatString(VkFormat format) noexcept;
+	static std::string_view getVkResultString(VkResult result) noexcept;
+	static std::string_view getVkFormatString(VkFormat format) noexcept;
 
 	// Returns minimal integer multiple of `alignment` not less than `size`. `alignment` must be a power of two.
 	static uint32_t alignUp(uint32_t size, uint32_t alignment) noexcept;

--- a/include/voxen/client/vulkan/high/terrain_synchronizer.hpp
+++ b/include/voxen/client/vulkan/high/terrain_synchronizer.hpp
@@ -71,6 +71,8 @@ private:
 
 	terrain::ChunkId m_gc_pointer = {};
 
+	// Indices of used Vulkan queues: { graphics, transfer }.
+	// If they are different then GPU has a dedicated DMA engine.
 	uint32_t m_queue_families[2];
 	bool m_vertex_uma = false;
 	bool m_index_uma = false;

--- a/include/voxen/client/vulkan/shader_module.hpp
+++ b/include/voxen/client/vulkan/shader_module.hpp
@@ -3,6 +3,7 @@
 #include <voxen/client/vulkan/common.hpp>
 
 #include <array>
+#include <string_view>
 
 namespace voxen::client::vulkan
 {
@@ -10,14 +11,14 @@ namespace voxen::client::vulkan
 class ShaderModule {
 public:
 	ShaderModule() = default;
-	explicit ShaderModule(const char *relative_path);
+	explicit ShaderModule(std::string_view relative_path);
 	ShaderModule(ShaderModule &&) = delete;
 	ShaderModule(const ShaderModule &) = delete;
 	ShaderModule &operator = (ShaderModule &&) = delete;
 	ShaderModule &operator = (const ShaderModule &) = delete;
 	~ShaderModule() noexcept;
 
-	void load(const char *relative_path);
+	void load(std::string_view relative_path);
 	void unload() noexcept;
 	bool isLoaded() const noexcept { return m_shader_module != VK_NULL_HANDLE; }
 

--- a/include/voxen/common/config.hpp
+++ b/include/voxen/common/config.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <extras/source_location.hpp>
+
 #include <filesystem>
-#include <variant>
+#include <map>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
-#include <map>
 
 #define SI_CONVERT_GENERIC
 #include <simpleini/SimpleIni.h>
@@ -15,7 +18,9 @@ namespace voxen
 
 class Config {
 public:
+	using Location = extras::source_location;
 	using option_t = std::variant<std::string, int64_t, double, bool>;
+
 	struct SchemeEntry {
 		std::string section;
 		std::string parameter_name;
@@ -28,16 +33,21 @@ public:
 	~Config() noexcept;
 
 	// Throws voxen::Exception("wrong parameter value type"), voxen::Exception("Option not found"), voxen::Exception("Inconsistent types of option values")
-	void patch(std::string_view section, std::string_view parameter_name, option_t value, bool saveToConfigFile = false);
+	void patch(std::string_view section, std::string_view parameter_name, std::string_view value_string,
+	           bool saveToConfigFile = false, Location loc = Location::current());
 
-	// Throws std::bad_variant_access, voxen::Exception("Option not found")
-	std::string optionString(std::string_view section, std::string_view parameter_name) const;
-	int64_t optionInt64(std::string_view section, std::string_view parameter_name) const;
-	int32_t optionInt32(std::string_view section, std::string_view parameter_name) const;
-	double optionDouble(std::string_view section, std::string_view  parameter_name) const;
-	bool optionBool(std::string_view section, std::string_view parameter_name) const;
+	std::optional<std::string> optionString(std::string_view section, std::string_view parameter_name) const;
+	std::optional<int64_t> optionInt64(std::string_view section, std::string_view parameter_name) const;
+	std::optional<int32_t> optionInt32(std::string_view section, std::string_view parameter_name) const;
+	std::optional<double> optionDouble(std::string_view section, std::string_view parameter_name) const;
+	std::optional<bool> optionBool(std::string_view section, std::string_view parameter_name) const;
 
-	size_t optionType(std::string_view section, std::string_view parameter_name) const;
+	int32_t getInt32(std::string_view section, std::string_view parameter_name,
+	                 Location loc = Location::current()) const;
+	double getDouble(std::string_view section, std::string_view parameter_name,
+	                 Location loc = Location::current()) const;
+	bool getBool(std::string_view section, std::string_view parameter_name,
+	             Location loc = Location::current()) const;
 
 public:
 

--- a/include/voxen/util/error_condition.hpp
+++ b/include/voxen/util/error_condition.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <system_error>
+
+namespace voxen
+{
+
+// This error code is supplemental to exception classes and is
+// intended to be tested and reacted on by exception handling.
+enum class VoxenErrc : int {
+	// Error happened in graphics subsystem
+	GfxFailure = 1,
+	// Graphics subsystem does not have the required capability
+	GfxCapabilityMissing = 2,
+	// Requested file does not exist or is inaccessible
+	FileNotFound = 3,
+	// Input data is invalid/corrupt and can't be used
+	InvalidData = 4,
+	// A finite resource was exhausted
+	OutOfResource = 5,
+	// A config object has no requested option but user assumes it exists
+	OptionMissing = 6,
+};
+
+// ADL-accessible factory for `std::error_condition { VoxenErrc }`
+std::error_condition make_error_condition(VoxenErrc errc) noexcept;
+
+}
+
+namespace std
+{
+
+// Mark `VoxenErrc` as eligible for `std::error_condition`
+template<>
+struct is_error_condition_enum<voxen::VoxenErrc> : true_type {};
+
+}

--- a/include/voxen/util/exception.hpp
+++ b/include/voxen/util/exception.hpp
@@ -1,51 +1,43 @@
 #pragma once
 
-#include <exception>
-#include <string>
-
 #include <extras/source_location.hpp>
 
-#include <fmt/core.h>
+#include <exception>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <variant>
 
 namespace voxen
 {
 
 class Exception : public std::exception {
 public:
-	explicit Exception(extras::source_location loc = extras::source_location::current()) noexcept;
-	virtual ~Exception();
+	using Location = extras::source_location;
 
-	extras::source_location where() const noexcept { return m_where; }
+	Exception() = delete;
+	Exception(Exception &&) = default;
+	Exception(const Exception &) = default;
+	Exception &operator = (Exception &&) = default;
+	Exception &operator = (const Exception &) = default;
+	~Exception() override = default;
 
-protected:
-	extras::source_location m_where;
-};
+	const char *what() const noexcept override;
+	const std::error_condition &error() const noexcept { return m_error; }
+	const Location &where() const noexcept { return m_where; }
 
-class MessageException : public Exception {
-public:
-	explicit MessageException(const char *msg = "", extras::source_location loc = extras::source_location::current())
-		noexcept : Exception(loc), m_what(msg) {}
-	virtual ~MessageException() = default;
-
-	virtual const char *what() const noexcept override;
-
-protected:
-	const char *m_what;
-};
-
-class ErrnoException : public Exception {
-public:
-	explicit ErrnoException(int code, const char *api = nullptr, extras::source_location loc =
-		extras::source_location::current()) noexcept;
-	virtual ~ErrnoException() = default;
-
-	virtual const char *what() const noexcept override;
-	int code() const noexcept { return m_code; }
+	static Exception fromError(std::error_condition error, const char *what = nullptr,
+	                           Location loc = Location::current()) noexcept;
+	static Exception fromFailedCall(std::error_condition error, std::string_view api,
+	                                Location loc = Location::current());
 
 protected:
-	std::string m_message;
-	int m_code;
-	bool m_exception_occured = false;
+	Exception(std::variant<const char *, std::string> what, std::error_condition error, Location loc) noexcept;
+
+private:
+	std::variant<const char *, std::string> m_what;
+	std::error_condition m_error;
+	Location m_where;
 };
 
 }

--- a/include/voxen/util/exception.hpp
+++ b/include/voxen/util/exception.hpp
@@ -33,19 +33,6 @@ protected:
 	const char *m_what;
 };
 
-class FormattedMessageException : public Exception {
-public:
-	explicit FormattedMessageException(std::string_view format_str, const fmt::format_args &format_args,
-		extras::source_location loc = extras::source_location::current()) noexcept;
-	virtual ~FormattedMessageException() = default;
-
-	virtual const char *what() const noexcept override;
-
-protected:
-	std::string m_what;
-	bool m_exception_occured = false;
-};
-
 class ErrnoException : public Exception {
 public:
 	explicit ErrnoException(int code, const char *api = nullptr, extras::source_location loc =

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ set(VOXEN_SOURCES
 	src/util/allocator.cpp
 	src/util/debug.cpp
 	src/util/elapsed_timer.cpp
+	src/util/error_condition.cpp
 	src/util/exception.cpp
 	src/util/hash.cpp
 	src/util/log.cpp

--- a/src/client/input_event_adapter.cpp
+++ b/src/client/input_event_adapter.cpp
@@ -207,12 +207,13 @@ void InputEventAdapter::init() {
 	actionSettingsConfig = new Config(FileManager::userDataPath() / actionSettingsPath, actionSettingConfigScheme);
 
 	for (const Config::SchemeEntry& entry : actionSettingConfigScheme) {
-		const string& value_string = actionSettingsConfig->optionString(entry.section, entry.parameter_name);
+		const string &default_value = std::get<string>(entry.default_value);
+		const string &value_string = actionSettingsConfig->optionString(entry.section,
+		                                                                entry.parameter_name).value_or(default_value);
 
 		string_view value(value_string);
 		PlayerActionEvent event = stringToAction(entry.parameter_name);
 
-		const string& default_value = std::get<string>(entry.default_value);
 		string_view parameter_name(entry.parameter_name);
 
 		if (event != PlayerActionEvent::None) {

--- a/src/client/input_event_adapter.cpp
+++ b/src/client/input_event_adapter.cpp
@@ -206,7 +206,6 @@ void InputEventAdapter::init() {
 	assert(actionSettingsConfig == nullptr);
 	actionSettingsConfig = new Config(FileManager::userDataPath() / actionSettingsPath, actionSettingConfigScheme);
 
-	std::function<void(string_view, voxen::client::PlayerActionEvent, string_view, string_view)> functor = InputEventAdapter::parseToken;
 	for (const Config::SchemeEntry& entry : actionSettingConfigScheme) {
 		const string& value_string = actionSettingsConfig->optionString(entry.section, entry.parameter_name);
 

--- a/src/client/render.cpp
+++ b/src/client/render.cpp
@@ -2,7 +2,7 @@
 
 #include <voxen/client/vulkan/high/main_loop.hpp>
 #include <voxen/client/vulkan/backend.hpp>
-
+#include <voxen/util/error_condition.hpp>
 #include <voxen/util/exception.hpp>
 #include <voxen/util/log.hpp>
 
@@ -14,7 +14,7 @@ Render::Render(Window &window)
 {
 	if (!vulkan::Backend::backend().start(m_window)) {
 		Log::error("Render subsystem couldn't launch");
-		throw MessageException("failed to start render subsystem");
+		throw Exception::fromError(VoxenErrc::GfxFailure, "failed to start render subsystem");
 	}
 }
 
@@ -31,20 +31,20 @@ void Render::drawFrame(const WorldState &world_state, const GameView &view)
 
 		if (state == vulkan::Backend::State::Broken) {
 			Log::error("Render subsystem encountered a non-recoverable error, shutting down");
-			throw MessageException("render subsystem failure");
+			throw Exception::fromError(VoxenErrc::GfxFailure, "render subsystem failure");
 		}
 		else if (state == vulkan::Backend::State::SurfaceLost) {
 			Log::info("Trying to recreate surface...");
 			if (!backend.recreateSurface(m_window)) {
 				Log::error("Surface recreation failed, shutting down");
-				throw MessageException("failed to recreate surface");
+				throw Exception::fromError(VoxenErrc::GfxFailure, "failed to recreate surface");
 			}
 		}
 		else if (state == vulkan::Backend::State::SwapchainOutOfDate) {
 			Log::info("Trying to recreate swapchain...");
 			if (!backend.recreateSwapchain(m_window)) {
 				Log::error("Swapchain recreation failed, shutting down");
-				throw MessageException("failed to recreate swapchain");
+				throw Exception::fromError(VoxenErrc::GfxFailure, "failed to recreate swapchain");
 			}
 		}
 		else {

--- a/src/client/vulkan/backend.cpp
+++ b/src/client/vulkan/backend.cpp
@@ -152,13 +152,13 @@ bool Backend::drawFrame(const WorldState &state, const GameView &view) noexcept
 		}
 		Log::error("what(): {}", e.what());
 		auto loc = e.where();
-		Log::error("where(): {}:{} ({})", loc.file_name(), loc.line(), loc.function_name());
+		Log::error("where(): {}:{}", loc.file_name(), loc.line());
 	}
 	catch (const Exception &e) {
 		Log::error("voxen::Exception during rendering a frame");
 		Log::error("what(): {}", e.what());
 		auto loc = e.where();
-		Log::error("where(): {}:{} ({})", loc.file_name(), loc.line(), loc.function_name());
+		Log::error("where(): {}:{}", loc.file_name(), loc.line());
 	}
 	catch (const std::exception &e) {
 		Log::error("std::exception during rendering a frame");
@@ -247,7 +247,7 @@ bool Backend::doStart(Window &window, StartStopMode mode) noexcept
 		Log::error("voxen::Exception was catched during starting Vulkan backend");
 		Log::error("what(): {}", e.what());
 		auto loc = e.where();
-		Log::error("where(): {}:{} ({})", loc.file_name(), loc.line(), loc.function_name());
+		Log::error("where(): {}:{}", loc.file_name(), loc.line());
 	}
 	catch (const std::exception &e) {
 		Log::error("std::exception was catched during starting Vulkan backend");

--- a/src/client/vulkan/common.cpp
+++ b/src/client/vulkan/common.cpp
@@ -28,14 +28,13 @@ VulkanException::VulkanException(VkResult result, const char *api, extras::sourc
 	: Exception(loc), m_result(result)
 {
 	try {
-		const char *err = VulkanUtils::getVkResultString(result);
-		const char *desc = VulkanUtils::getVkResultDescription(result);
+		std::string_view err = VulkanUtils::getVkResultString(result);
 		if (api) {
 			Log::error("{} failed with error code {}", api, err, loc);
-			m_message = fmt::format("{} failed: {} ({})", api, err, desc);
+			m_message = fmt::format("{} failed: {}", api, err);
 		} else {
 			Log::error("Vulkan API call failed with error code {}", err, loc);
-			m_message = fmt::format("Vulkan error: {} ({})", err, desc);
+			m_message = fmt::format("Vulkan error: {}", err);
 		}
 	} catch (...) {
 		m_exception_occured = true;
@@ -145,115 +144,67 @@ const VkAllocationCallbacks *HostAllocator::callbacks() noexcept
 	return nullptr;
 }
 
-const char *VulkanUtils::getVkResultString(VkResult result) noexcept
+std::string_view VulkanUtils::getVkResultString(VkResult result) noexcept
 {
-	// Copy-pasted from Vulkan spec 1.2.132
+	using namespace std::string_view_literals;
+
+#define CASE(err) case err: return #err##sv
 	switch (result) {
 	// Result codes
-	case VK_SUCCESS: return "VK_SUCCESS";
-	case VK_NOT_READY: return "VK_NOT_READY";
-	case VK_TIMEOUT: return "VK_TIMEOUT";
-	case VK_EVENT_SET: return "VK_EVENT_SET";
-	case VK_EVENT_RESET: return "VK_EVENT_RESET";
-	case VK_INCOMPLETE: return "VK_INCOMPLETE";
-	case VK_SUBOPTIMAL_KHR: return "VK_SUBOPTIMAL_KHR";
+	CASE(VK_SUCCESS);
+	CASE(VK_NOT_READY);
+	CASE(VK_TIMEOUT);
+	CASE(VK_EVENT_SET);
+	CASE(VK_EVENT_RESET);
+	CASE(VK_INCOMPLETE);
+	CASE(VK_SUBOPTIMAL_KHR);
+	CASE(VK_THREAD_IDLE_KHR);
+	CASE(VK_THREAD_DONE_KHR);
+	CASE(VK_OPERATION_DEFERRED_KHR);
+	CASE(VK_OPERATION_NOT_DEFERRED_KHR);
+	CASE(VK_PIPELINE_COMPILE_REQUIRED);
 	// Error codes
-	case VK_ERROR_OUT_OF_HOST_MEMORY: return "VK_ERROR_OUT_OF_HOST_MEMORY";
-	case VK_ERROR_OUT_OF_DEVICE_MEMORY: return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
-	case VK_ERROR_INITIALIZATION_FAILED: return "VK_ERROR_INITIALIZATION_FAILED";
-	case VK_ERROR_DEVICE_LOST: return "VK_ERROR_DEVICE_LOST";
-	case VK_ERROR_MEMORY_MAP_FAILED: return "VK_ERROR_MEMORY_MAP_FAILED";
-	case VK_ERROR_LAYER_NOT_PRESENT: return "VK_ERROR_LAYER_NOT_PRESENT";
-	case VK_ERROR_EXTENSION_NOT_PRESENT: return "VK_ERROR_EXTENSION_NOT_PRESENT";
-	case VK_ERROR_FEATURE_NOT_PRESENT: return "VK_ERROR_FEATURE_NOT_PRESENT";
-	case VK_ERROR_INCOMPATIBLE_DRIVER: return "VK_ERROR_INCOMPATIBLE_DRIVER";
-	case VK_ERROR_TOO_MANY_OBJECTS: return "VK_ERROR_TOO_MANY_OBJECTS";
-	case VK_ERROR_FORMAT_NOT_SUPPORTED: return "VK_ERROR_FORMAT_NOT_SUPPORTED";
-	case VK_ERROR_FRAGMENTED_POOL: return "VK_ERROR_FRAGMENTED_POOL";
-	case VK_ERROR_UNKNOWN: return "VK_ERROR_UNKNOWN";
-	case VK_ERROR_OUT_OF_POOL_MEMORY: return "VK_ERROR_OUT_OF_POOL_MEMORY";
-	case VK_ERROR_INVALID_EXTERNAL_HANDLE: return "VK_ERROR_INVALID_EXTERNAL_HANDLE";
-	case VK_ERROR_FRAGMENTATION: return "VK_ERROR_FRAGMENTATION";
-	case VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS: return "VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS";
-	case VK_ERROR_SURFACE_LOST_KHR: return "VK_ERROR_SURFACE_LOST_KHR";
-	case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR: return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
-	case VK_ERROR_OUT_OF_DATE_KHR: return "VK_ERROR_OUT_OF_DATE_KHR";
-	case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR: return "VK_ERROR_INCOMPATIBLE_DISPLAY_KHR";
-	case VK_ERROR_VALIDATION_FAILED_EXT: return "VK_ERROR_VALIDATION_FAILED_EXT";
-	case VK_ERROR_INVALID_SHADER_NV: return "VK_ERROR_INVALID_SHADER_NV";
-	case VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT:
-		return "VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT";
-	case VK_ERROR_NOT_PERMITTED_EXT: return "VK_ERROR_NOT_PERMITTED_EXT";
-	case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT: return "VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT";
-	default: return "[UNKNOWN]";
+	CASE(VK_ERROR_OUT_OF_HOST_MEMORY);
+	CASE(VK_ERROR_OUT_OF_DEVICE_MEMORY);
+	CASE(VK_ERROR_INITIALIZATION_FAILED);
+	CASE(VK_ERROR_DEVICE_LOST);
+	CASE(VK_ERROR_MEMORY_MAP_FAILED);
+	CASE(VK_ERROR_LAYER_NOT_PRESENT);
+	CASE(VK_ERROR_EXTENSION_NOT_PRESENT);
+	CASE(VK_ERROR_FEATURE_NOT_PRESENT);
+	CASE(VK_ERROR_INCOMPATIBLE_DRIVER);
+	CASE(VK_ERROR_TOO_MANY_OBJECTS);
+	CASE(VK_ERROR_FORMAT_NOT_SUPPORTED);
+	CASE(VK_ERROR_FRAGMENTED_POOL);
+	CASE(VK_ERROR_UNKNOWN);
+	CASE(VK_ERROR_OUT_OF_POOL_MEMORY);
+	CASE(VK_ERROR_INVALID_EXTERNAL_HANDLE);
+	CASE(VK_ERROR_FRAGMENTATION);
+	CASE(VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS);
+	CASE(VK_ERROR_SURFACE_LOST_KHR);
+	CASE(VK_ERROR_NATIVE_WINDOW_IN_USE_KHR);
+	CASE(VK_ERROR_OUT_OF_DATE_KHR);
+	CASE(VK_ERROR_INCOMPATIBLE_DISPLAY_KHR);
+	CASE(VK_ERROR_VALIDATION_FAILED_EXT);
+	CASE(VK_ERROR_INVALID_SHADER_NV);
+	CASE(VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT);
+	CASE(VK_ERROR_NOT_PERMITTED_KHR);
+	CASE(VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT);
+	CASE(VK_ERROR_COMPRESSION_EXHAUSTED_EXT);
+	// Just to satisfy -Wswitch
+	CASE(VK_RESULT_MAX_ENUM);
+	// No `default` to make `-Werror -Wswitch` protection work
 	}
+#undef CASE
 }
 
-const char *VulkanUtils::getVkResultDescription(VkResult result) noexcept
+std::string_view VulkanUtils::getVkFormatString(VkFormat format) noexcept
 {
-	// Copy-pasted from Vulkan spec 1.2.132
-	switch (result) {
-	// Result codes
-	case VK_SUCCESS: return "Command successfully completed";
-	case VK_NOT_READY: return "A fence or query has not yet completed";
-	case VK_TIMEOUT: return "A wait operation has not completed in the specified time";
-	case VK_EVENT_SET: return "An event is signaled";
-	case VK_EVENT_RESET: return "An event is unsignaled";
-	case VK_INCOMPLETE: return "A return array was too small for the result";
-	case VK_SUBOPTIMAL_KHR:
-		return "A swapchain no longer matches the surface properties exactly, "
-		       "but can still be used to present to the surface successfully";
-	// Error codes
-	case VK_ERROR_OUT_OF_HOST_MEMORY: return "A host memory allocation has failed";
-	case VK_ERROR_OUT_OF_DEVICE_MEMORY: return "A device memory allocation has failed";
-	case VK_ERROR_INITIALIZATION_FAILED:
-		return "Initialization of an object could not be completed for implementation-specific reasons";
-	case VK_ERROR_DEVICE_LOST: return "The logical or physical device has been lost";
-	case VK_ERROR_MEMORY_MAP_FAILED: return "Mapping of a memory object has failed";
-	case VK_ERROR_LAYER_NOT_PRESENT: return "A requested layer is not present or could not be loaded";
-	case VK_ERROR_EXTENSION_NOT_PRESENT: return "A requested extension is not supported";
-	case VK_ERROR_FEATURE_NOT_PRESENT: return "A requested feature is not supported";
-	case VK_ERROR_INCOMPATIBLE_DRIVER:
-		return "The requested version of Vulkan is not supported by the driver "
-		       "or is otherwise incompatible for implementation-specific reasons";
-	case VK_ERROR_TOO_MANY_OBJECTS: return "Too many objects of the type have already been created";
-	case VK_ERROR_FORMAT_NOT_SUPPORTED: return "A requested format is not supported on this device";
-	case VK_ERROR_FRAGMENTED_POOL: return "A pool allocation has failed due to fragmentation of the pool’s memory";
-	case VK_ERROR_UNKNOWN:
-		return "An unknown error has occurred; either the application "
-		       "has provided invalid input, or an implementation failure has occurred";
-	case VK_ERROR_OUT_OF_POOL_MEMORY: return "A pool memory allocation has failed";
-	case VK_ERROR_INVALID_EXTERNAL_HANDLE: return "An external handle is not a valid handle of the specified type";
-	case VK_ERROR_FRAGMENTATION: return "A descriptor pool creation has failed due to fragmentation";
-	case VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS:
-		return "A buffer creation or memory allocation failed because the requested address is not available";
-	case VK_ERROR_SURFACE_LOST_KHR: return "A surface is no longer available";
-	case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
-		return "The requested window is already in use by Vulkan "
-		       "or another API in a manner which prevents it from being used again";
-	case VK_ERROR_OUT_OF_DATE_KHR:
-		return "A surface has changed in such a way that it is no longer compatible with "
-		       "the swapchain, and further presentation requests using the swapchain will fail";
-	case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
-		return "The display used by a swapchain does not use the same presentable "
-		       "image layout, or is incompatible in a way that prevents sharing an image";
-	case VK_ERROR_VALIDATION_FAILED_EXT: return "No description in spec";
-	case VK_ERROR_INVALID_SHADER_NV: return "One or more shaders failed to compile or link";
-	case VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT:
-		return "No description in spec";
-	case VK_ERROR_NOT_PERMITTED_EXT: return "The caller does not have sufficient privileges";
-	case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT:
-		return "An operation on a swapchain created with VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT "
-		       "failed as it did not have exlusive full-screen access";
-	default: return "Unknown or wrong VkResult value";
-	}
-}
+	using namespace std::string_view_literals;
 
-const char *VulkanUtils::getVkFormatString(VkFormat format) noexcept
-{
 	// The list is copy-pasted from Vulkan 1.2.170 headers.
 	// Multiplane, some block, 4-bit, scaled and other crazy formats were removed.
-#define FORMAT_ENTRY(fmt) case fmt: return #fmt
+#define FORMAT_ENTRY(fmt) case fmt: return #fmt##sv
 	switch (format) {
 	FORMAT_ENTRY(VK_FORMAT_UNDEFINED);
 	FORMAT_ENTRY(VK_FORMAT_R8_UNORM);
@@ -358,7 +309,7 @@ const char *VulkanUtils::getVkFormatString(VkFormat format) noexcept
 	FORMAT_ENTRY(VK_FORMAT_BC6H_SFLOAT_BLOCK);
 	FORMAT_ENTRY(VK_FORMAT_BC7_UNORM_BLOCK);
 	FORMAT_ENTRY(VK_FORMAT_BC7_SRGB_BLOCK);
-	default: return "Unknown or wrong VkFormat value";
+	default: return "VK_FORMAT_[UNKNOWN]"sv;
 	}
 #undef FORMAT_ENTRY
 }

--- a/src/client/vulkan/common.cpp
+++ b/src/client/vulkan/common.cpp
@@ -6,6 +6,35 @@
 #include <cstddef>
 #include <malloc.h>
 
+namespace
+{
+
+struct VulkanErrorCategory : std::error_category {
+	const char *name() const noexcept override
+	{
+		return "Vulkan error";
+	}
+
+	std::string message(int code) const override
+	{
+		return std::string(voxen::client::vulkan::VulkanUtils::getVkResultString(VkResult(code)));
+	}
+};
+
+const VulkanErrorCategory g_category;
+
+} // anonymous namespace
+
+namespace std
+{
+
+error_condition make_error_condition(VkResult result) noexcept
+{
+	return { static_cast<int>(result), g_category };
+}
+
+}
+
 namespace voxen::client::vulkan
 {
 

--- a/src/client/vulkan/device.cpp
+++ b/src/client/vulkan/device.cpp
@@ -2,7 +2,7 @@
 
 #include <voxen/client/vulkan/backend.hpp>
 #include <voxen/client/vulkan/physical_device.hpp>
-
+#include <voxen/util/error_condition.hpp>
 #include <voxen/util/exception.hpp>
 #include <voxen/util/log.hpp>
 
@@ -22,7 +22,7 @@ Device::Device()
 	auto &backend = Backend::backend();
 	if (!backend.loadDeviceLevelApi(m_device)) {
 		destroyDevice();
-		throw MessageException("failed to load device-level Vulkan API");
+		throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "missing required device-level Vulkan API");
 	}
 
 	obtainQueueHandles();

--- a/src/client/vulkan/high/mesh.cpp
+++ b/src/client/vulkan/high/mesh.cpp
@@ -4,7 +4,6 @@
 #include <voxen/client/vulkan/backend.hpp>
 
 #include <voxen/util/log.hpp>
-#include <voxen/config.hpp>
 
 namespace voxen::client::vulkan
 {
@@ -18,9 +17,7 @@ VkDeviceSize getVertexElementSize(VertexFormat fmt) noexcept
 		return 3 * 4;
 	case VertexFormat::Pos3D_Norm3D:
 		return 3 * 4 + 3 * 4;
-	default:
-		Log::error("Unknown vertex format");
-		return 0;
+	// No `default` to make `-Werror -Wswitch` protection work
 	}
 }
 
@@ -35,9 +32,7 @@ VkDeviceSize getIndexElementSize(IndexFormat fmt) noexcept
 		return 2;
 	case IndexFormat::Index32:
 		return 4;
-	default:
-		Log::error("Unknown index format");
-		return 0;
+	// No `default` to make `-Werror -Wswitch` protection work
 	}
 }
 
@@ -52,35 +47,16 @@ VkIndexType getIndexType(IndexFormat fmt) noexcept
 		return VK_INDEX_TYPE_UINT16;
 	case IndexFormat::Index32:
 		return VK_INDEX_TYPE_UINT32;
-	default:
-		Log::error("Unknown index format");
-		return VK_INDEX_TYPE_NONE_KHR;
+	// No `default` to make `-Werror -Wswitch` protection work
 	}
 }
 
 Mesh::Mesh(const MeshCreateInfo &create_info)
 	: m_vertex_format(create_info.vertex_format), m_index_format(create_info.index_format)
 {
-	// These are just sanity checks
-	if constexpr (BuildConfig::kIsDebugBuild) {
-		constexpr const char *EXCEPTION_TEXT = "refusing to make zero-sized buffer";
-		if (m_vertex_format == VertexFormat::Nothing && create_info.num_vertices > 0) {
-			Log::error("Vertex format is 'Nothing' but there are {} vertices", create_info.num_vertices);
-			throw MessageException(EXCEPTION_TEXT);
-		}
-		if (m_vertex_format != VertexFormat::Nothing && create_info.num_vertices == 0) {
-			Log::error("Vertex format is not 'Nothing' but there are 0 vertices");
-			throw MessageException(EXCEPTION_TEXT);
-		}
-		if (m_index_format == IndexFormat::Nothing && create_info.num_indices > 0) {
-			Log::error("Index format is 'Nothing' but there are {} indices", create_info.num_indices);
-			throw MessageException(EXCEPTION_TEXT);
-		}
-		if (m_index_format != IndexFormat::Nothing && create_info.num_indices == 0) {
-			Log::error("Index format is not 'Nothing' but there are 0 indices");
-			throw MessageException(EXCEPTION_TEXT);
-		}
-	}
+	// Sanity checks - there must be no vertices/indices with Nothing format and non-zero otherwise
+	assert(m_vertex_format == VertexFormat::Nothing ? create_info.num_vertices == 0 : create_info.num_vertices > 0);
+	assert(m_index_format == IndexFormat::Nothing ? create_info.num_indices == 0 : create_info.num_indices > 0);
 
 	TransferManager &transfer = Backend::backend().transferManager();
 

--- a/src/client/vulkan/high/terrain_synchronizer.cpp
+++ b/src/client/vulkan/high/terrain_synchronizer.cpp
@@ -5,6 +5,7 @@
 #include <voxen/client/vulkan/physical_device.hpp>
 #include <voxen/client/vulkan/high/transfer_manager.hpp>
 #include <voxen/common/terrain/surface.hpp>
+#include <voxen/util/error_condition.hpp>
 #include <voxen/util/log.hpp>
 
 #include <extras/linear_allocator.hpp>
@@ -348,7 +349,7 @@ void TerrainSynchronizer::addVertexArena()
 		if (!res) {
 			m_vertex_arenas.pop_back();
 			Log::error("Inconsistent vertex arena host visibility!");
-			throw MessageException("inconsistent host visibility for same objects");
+			throw Exception::fromError(VoxenErrc::GfxFailure, "inconsistent host visibility for same objects");
 		}
 	}
 
@@ -382,7 +383,7 @@ void TerrainSynchronizer::addIndexArena()
 		if (!res) {
 			m_index_arenas.pop_back();
 			Log::info("Inconsistent index arena host visibility!");
-			throw MessageException("inconsistent host visibility for same objects");
+			throw Exception::fromError(VoxenErrc::GfxFailure, "inconsistent host visibility for same objects");
 		}
 	}
 

--- a/src/client/vulkan/instance.cpp
+++ b/src/client/vulkan/instance.cpp
@@ -2,10 +2,10 @@
 
 #include <voxen/client/vulkan/backend.hpp>
 #include <voxen/client/vulkan/capabilities.hpp>
-
-#include <voxen/config.hpp>
+#include <voxen/util/error_condition.hpp>
 #include <voxen/util/exception.hpp>
 #include <voxen/util/log.hpp>
+#include <voxen/config.hpp>
 
 #include <GLFW/glfw3.h>
 
@@ -17,7 +17,7 @@ Instance::Instance()
 	Log::debug("Creating Instance");
 
 	if (!checkVulkanSupport()) {
-		throw MessageException("unsupported or missing Vulkan driver");
+		throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "unsupported or missing Vulkan driver");
 	}
 
 	createInstance();
@@ -26,7 +26,7 @@ Instance::Instance()
 	if (!backend.loadInstanceLevelApi(m_handle)) {
 		// Assuming at least vkDestroyInstance was found...
 		destroyInstance();
-		throw MessageException("failed to load instance-level Vulkan API");
+		throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "missing required instance-level Vulkan API");
 	}
 
 	Log::debug("Instance created successfully");

--- a/src/client/vulkan/memory.cpp
+++ b/src/client/vulkan/memory.cpp
@@ -4,6 +4,7 @@
 #include <voxen/client/vulkan/config.hpp>
 #include <voxen/client/vulkan/device.hpp>
 #include <voxen/client/vulkan/physical_device.hpp>
+#include <voxen/util/error_condition.hpp>
 #include <voxen/util/log.hpp>
 
 #include <extras/linear_allocator.hpp>
@@ -338,7 +339,7 @@ DeviceAllocation DeviceAllocator::allocateInternal(const AllocationInfo &info,
 	if (info.size >= size_limit) [[unlikely]] {
 		Log::error("Requested allocation of size {:.1f} MB is too big for memory type #{} (limit is {:.1f} MB)",
 			toMegabytes(info.size), memory_type, toMegabytes(size_limit));
-		throw MessageException("refusing too big allocation");
+		throw Exception::fromError(VoxenErrc::OutOfResource, "refusing too big allocation");
 	}
 
 	if (dedicated_info) {
@@ -411,7 +412,7 @@ uint32_t DeviceAllocator::selectMemoryType(const AllocationInfo &info) const
 	if (best_type == UINT32_MAX) {
 		Log::error("Suitable memory type not found for request with memtype mask 0b{:b}, use case '{}'",
 			info.acceptable_memory_types, extras::enum_name(info.use_case));
-		throw MessageException("no suitable Vulkan memory type found");
+		throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "no suitable Vulkan memory type found");
 	}
 
 	return best_type;

--- a/src/client/vulkan/physical_device.cpp
+++ b/src/client/vulkan/physical_device.cpp
@@ -3,7 +3,7 @@
 #include <voxen/client/vulkan/backend.hpp>
 #include <voxen/client/vulkan/capabilities.hpp>
 #include <voxen/client/vulkan/instance.hpp>
-
+#include <voxen/util/error_condition.hpp>
 #include <voxen/util/exception.hpp>
 #include <voxen/util/log.hpp>
 
@@ -29,7 +29,7 @@ PhysicalDevice::PhysicalDevice()
 		throw VulkanException(result, "vkEnumeratePhysicalDevices");
 	if (num_devices == 0) {
 		Log::error("No Vulkan physical devices are present in the system");
-		throw MessageException("no Vulkan devices found");
+		throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "no Vulkan devices found");
 	}
 
 	extras::dyn_array<VkPhysicalDevice> devices(num_devices);
@@ -53,7 +53,7 @@ PhysicalDevice::PhysicalDevice()
 
 	if (m_device == VK_NULL_HANDLE) {
 		Log::error("No suitable Vulkan physical device found in the system");
-		throw MessageException("not suitable Vulkan devices found");
+		throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "no suitable Vulkan devices found");
 	}
 
 	Log::debug("PhysicalDevice created successfully");

--- a/src/client/vulkan/shader_module.cpp
+++ b/src/client/vulkan/shader_module.cpp
@@ -9,19 +9,14 @@
 namespace voxen::client::vulkan
 {
 
-ShaderModule::ShaderModule(const char *relative_path)
+ShaderModule::ShaderModule(std::string_view relative_path)
 {
 	load(relative_path);
 }
 
-void ShaderModule::load(const char *relative_path)
+void ShaderModule::load(std::string_view relative_path)
 {
 	unload();
-
-	if (!relative_path) {
-		Log::error("Null pointer passed as path");
-		throw MessageException("null pointer");
-	}
 
 	Log::debug("Loading shader module `{}`", relative_path);
 	auto code = FileManager::readFile(relative_path);

--- a/src/client/vulkan/surface.cpp
+++ b/src/client/vulkan/surface.cpp
@@ -4,7 +4,7 @@
 #include <voxen/client/vulkan/device.hpp>
 #include <voxen/client/vulkan/instance.hpp>
 #include <voxen/client/vulkan/physical_device.hpp>
-
+#include <voxen/util/error_condition.hpp>
 #include <voxen/util/log.hpp>
 
 #include <extras/defer.hpp>
@@ -58,7 +58,7 @@ void Surface::checkPresentSupport()
 	if (!supported) {
 		Log::error("Selected GPU can't present to this window surface");
 		Log::error("Earlier checks passed - most probably it's a bug in Voxen or GLFW");
-		throw MessageException("physical device can't present to window surface");
+		throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "Vulkan device can't present to window");
 	}
 }
 
@@ -88,7 +88,7 @@ void Surface::pickSurfaceFormat()
 		}
 	}
 	Log::error("Surface format BGRA8_SRGB not found");
-	throw MessageException("failed to find suitable surface format");
+	throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "failed to find suitable surface format");
 }
 
 void Surface::pickPresentMode()
@@ -118,7 +118,7 @@ void Surface::pickPresentMode()
 		}
 	}
 	Log::error("Present mode VK_PRESENT_MODE_FIFO_KHR not found");
-	throw MessageException("failed to find suitable present mode");
+	throw Exception::fromError(VoxenErrc::GfxCapabilityMissing, "failed to find suitable present mode");
 }
 
 }

--- a/src/client/vulkan/swapchain.cpp
+++ b/src/client/vulkan/swapchain.cpp
@@ -5,7 +5,6 @@
 #include <voxen/client/vulkan/instance.hpp>
 #include <voxen/client/vulkan/physical_device.hpp>
 #include <voxen/client/vulkan/surface.hpp>
-
 #include <voxen/util/log.hpp>
 
 #include <extras/defer.hpp>
@@ -145,11 +144,8 @@ void Swapchain::destroySwapchain() noexcept
 VkExtent2D Swapchain::pickImageExtent(const VkSurfaceCapabilitiesKHR &caps)
 {
 	VkExtent2D result;
-	if (caps.currentExtent.width == 0 && caps.currentExtent.height == 0) {
-		// TODO: should it be merged with the second case instead?
-		Log::error("Current surface extent is (0, 0), can't create swapchain now (window is minimized?)");
-		throw MessageException("can't create swapchain now");
-	} else if (caps.currentExtent.width == UINT32_MAX && caps.currentExtent.height == UINT32_MAX) {
+	if ((caps.currentExtent.width == 0 && caps.currentExtent.height == 0) ||
+	    (caps.currentExtent.width == UINT32_MAX && caps.currentExtent.height == UINT32_MAX)) {
 		Log::debug("Current surface extent is undefined, using GLFW window size");
 		auto[width, height] = Backend::backend().surface().window().framebufferSize();
 		result.width = std::clamp(uint32_t(width), caps.minImageExtent.width, caps.maxImageExtent.width);

--- a/src/client/window.cpp
+++ b/src/client/window.cpp
@@ -71,7 +71,7 @@ void Window::createWindow(int width, int height)
 
 	Config *cfg = Config::mainConfig();
 	GLFWmonitor *monitor = nullptr;
-	if (cfg->optionBool("window"sv, "fullscreen"sv)) {
+	if (cfg->getBool("window"sv, "fullscreen"sv)) {
 		// TODO: add possibility select non-primary monitor?
 		monitor = glfwGetPrimaryMonitor();
 	}

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -1,10 +1,12 @@
 #include <voxen/common/config.hpp>
 
-#include <voxen/util/exception.hpp>
 #include <voxen/common/filemanager.hpp>
+#include <voxen/util/exception.hpp>
 #include <voxen/util/log.hpp>
 
 #include <fmt/format.h>
+
+#include <cassert>
 
 using namespace std::filesystem;
 using std::string_view;
@@ -82,7 +84,8 @@ bool Config::optionBool(string_view section, string_view parameter_name) const
 		}
 	}
 
-	throw FormattedMessageException("Bool option {}/{} not found", fmt::make_format_args(section, parameter_name));
+	Log::error("Bool option {}/{} not found", section, parameter_name);
+	throw MessageException("option not found");
 }
 
 double Config::optionDouble(string_view section, string_view parameter_name) const
@@ -95,7 +98,8 @@ double Config::optionDouble(string_view section, string_view parameter_name) con
 		}
 	}
 
-	throw FormattedMessageException("Double option {}/{} not found", fmt::make_format_args(section, parameter_name));
+	Log::error("Double option {}/{} not found", section, parameter_name);
+	throw MessageException("option not found");
 }
 
 int64_t Config::optionInt64(string_view section, string_view parameter_name) const
@@ -107,7 +111,8 @@ int64_t Config::optionInt64(string_view section, string_view parameter_name) con
 			return std::get<int64_t>(it_inter->second);
 	}
 
-	throw FormattedMessageException("Int option {}/{} not found", fmt::make_format_args(section, parameter_name));
+	Log::error("Int option {}/{} not found", section, parameter_name);
+	throw MessageException("option not found");
 }
 
 int32_t Config::optionInt32(string_view section, string_view parameter_name) const
@@ -127,7 +132,8 @@ std::string Config::optionString(string_view section, string_view parameter_name
 			return std::get<std::string>(it_inter->second);
 	}
 
-	throw FormattedMessageException("String option {}/{} not found", fmt::make_format_args(section, parameter_name));
+	Log::error("String option {}/{} not found", section, parameter_name);
+	throw MessageException("option not found");
 }
 
 size_t Config::optionType(string_view section, string_view parameter_name) const
@@ -139,7 +145,8 @@ size_t Config::optionType(string_view section, string_view parameter_name) const
 			return it_inter->second.index();
 	}
 
-	throw FormattedMessageException("Option {}/{} not found", fmt::make_format_args(section, parameter_name));
+	Log::error("Option {}/{} not found", section, parameter_name);
+	throw MessageException("option not found");
 }
 
 void Config::patch(string_view section, string_view parameter_name, option_t value, bool saveToConfigFile)
@@ -155,15 +162,16 @@ void Config::patch(string_view section, string_view parameter_name, option_t val
 					m_ini.SetValue(section.data(), parameter_name.data(), str.c_str());
 				}
 				return;
-			} else {
-				throw FormattedMessageException(
-					"Inconsistent types for option {}/{}: try replace {} with {}", fmt::make_format_args(section, parameter_name, it_inter->second.index(), value.index())
-				);
 			}
+
+			Log::error("Inconsistent types for option {}/{}: try replacing {} with {}",
+			           section, parameter_name, it_inter->second.index(), value.index());
+			throw MessageException("inconsistent option types");
 		}
 	}
 
-	throw FormattedMessageException("Option {}/{} not found", fmt::make_format_args(section, parameter_name));
+	Log::error("Option {}/{} not found", section, parameter_name);
+	throw MessageException("option not found");
 }
 
 std::string Config::optionToString(option_t value)

--- a/src/common/gameview.cpp
+++ b/src/common/gameview.cpp
@@ -27,10 +27,10 @@ GameView::GameView (client::Window& window):
 	m_fov_y = 1.5 * (double)window.height() / (double)window.width();
 
 	Config* main_config = Config::mainConfig();
-	m_mouse_sensitivity = main_config->optionDouble("controller", "mouse_sensitivity");
-	m_forward_speed = main_config->optionDouble("controller", "forward_speed");
-	m_strafe_speed = main_config->optionDouble("controller", "strafe_speed");
-	m_roll_speed = main_config->optionDouble("controller", "roll_speed");
+	m_mouse_sensitivity = main_config->getDouble("controller", "mouse_sensitivity");
+	m_forward_speed = main_config->getDouble("controller", "forward_speed");
+	m_strafe_speed = main_config->getDouble("controller", "strafe_speed");
+	m_roll_speed = main_config->getDouble("controller", "roll_speed");
 
 	resetKeyState();
 }

--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -75,11 +75,10 @@ ThreadPool::~ThreadPool() noexcept
 	}
 }
 
-void ThreadPool::doEnqueueTask(TaskType type, std::packaged_task<void()> task)
+void ThreadPool::doEnqueueTask([[maybe_unused]] TaskType type, std::packaged_task<void()> task)
 {
-	if (type != TaskType::Standard) {
-		throw MessageException("non-standard tasks are not supported yet");
-	}
+	// non-standard tasks are not supported yet
+	assert(type == TaskType::Standard);
 
 	size_t min_job_count = SIZE_MAX;
 	ReportableWorker *min_job_thread = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
 		Log::fatal("Unchaught voxen::Exception instance");
 		Log::fatal("what(): {}", e.what());
 		auto loc = e.where();
-		Log::fatal("where(): {}:{} ({})", loc.file_name(), loc.line(), loc.function_name());
+		Log::fatal("where(): {}:{}", loc.file_name(), loc.line());
 		Log::fatal("Aborting the program");
 		return EXIT_FAILURE;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,9 +79,7 @@ void patchConfig(const cxxopts::ParseResult &result, voxen::Config* config) {
 		std::string section = keyvalue.key().substr(0, sep_idx);
 		std::string parameter = keyvalue.key().substr(sep_idx+kCliSectionSeparator.size());
 
-		size_t type_idx = config->optionType(section, parameter);
-		voxen::Config::option_t value = voxen::Config::optionFromString(keyvalue.value(), type_idx);
-		config->patch(section, parameter, value);
+		config->patch(section, parameter, keyvalue.value());
 	}
 }
 
@@ -134,10 +132,10 @@ int main(int argc, char *argv[])
 		voxen::Config* main_voxen_config = voxen::Config::mainConfig();
 		patchConfig(result, main_voxen_config);
 
-		bool isLoggingFPSEnable = main_voxen_config->optionBool("dev", "fps_logging");
+		bool isLoggingFPSEnable = main_voxen_config->getBool("dev", "fps_logging");
 
 		auto &wnd = voxen::client::Window::instance();
-		wnd.start(main_voxen_config->optionInt32("window", "width"), main_voxen_config->optionInt32("window", "height"));
+		wnd.start(main_voxen_config->getInt32("window", "width"), main_voxen_config->getInt32("window", "height"));
 		auto render = std::make_unique<voxen::client::Render>(wnd);
 
 		voxen::server::World world;

--- a/src/util/error_condition.cpp
+++ b/src/util/error_condition.cpp
@@ -1,0 +1,40 @@
+#include <voxen/util/error_condition.hpp>
+
+namespace voxen
+{
+
+namespace
+{
+
+struct VoxenErrorCategory : std::error_category {
+	const char *name() const noexcept override
+	{
+		return "Voxen error";
+	}
+
+	std::string message(int code) const override
+	{
+		switch (static_cast<VoxenErrc>(code)) {
+		case VoxenErrc::GfxFailure: return "Error happened in graphics subsystem";
+		case VoxenErrc::GfxCapabilityMissing: return "Graphics subsystem does not have the required capability";
+		case VoxenErrc::FileNotFound: return "Requested file does not exist or is inaccessible";
+		case VoxenErrc::InvalidData: return "Input data is invalid/corrupt and can't be used";
+		case VoxenErrc::OutOfResource: return "A finite resource was exhausted";
+		case VoxenErrc::OptionMissing: return "A config object has no requested option but user assumes it exists";
+		// No `default` to make `-Werror -Wswitch` protection work
+		}
+
+		return "Unknown error";
+	}
+};
+
+const VoxenErrorCategory g_category;
+
+} // anonymous namespace
+
+std::error_condition make_error_condition(VoxenErrc errc) noexcept
+{
+	return { static_cast<int>(errc), g_category };
+}
+
+}

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -1,53 +1,44 @@
-#include <voxen/util/exception.hpp>
+﻿#include <voxen/util/exception.hpp>
 
-#include <voxen/util/log.hpp>
+#include <voxen/util/error_condition.hpp>
 
 #include <fmt/format.h>
 
-#include <cstring>
+#include <cassert>
 
 namespace voxen
 {
 
-Exception::Exception(extras::source_location loc) noexcept : m_where(loc)
+const char *Exception::what() const noexcept
 {
-	// TODO: this is the best place to print stack trace
-}
-
-Exception::~Exception() = default;
-
-const char *MessageException::what() const noexcept
-{
-	return m_what;
-}
-
-ErrnoException::ErrnoException(int code, const char *api, extras::source_location loc) noexcept
-	: Exception(loc), m_code(code)
-{
-	try {
-		char buf[1024];
-		const char *description = strerror_r(code, buf, 1024);
-		if (api) {
-			Log::error("{} failed with error code {} ({})", api, code, description, loc);
-			m_message = fmt::format("Error code {}: {}", code, description);
-		} else {
-			m_message = fmt::format("Error code {}: {}", code, description);
-		}
-	} catch (...) {
-		m_exception_occured = true;
-	}
-}
-
-const char *ErrnoException::what() const noexcept
-{
-	constexpr static char EXCEPTION_OCCURED_MSG[] =
-		"Exception occured during creating ErrnoException, message is lost";
-
-	if (m_exception_occured) {
-		return EXCEPTION_OCCURED_MSG;
+	if (const std::string *str = std::get_if<std::string>(&m_what); str) {
+		return str->c_str();
 	}
 
-	return m_message.c_str();
+	// Can directly use `std::get<const char *>()` here but this will trip exception-escape analyzer
+	if (const char * const *pstr = std::get_if<const char *>(&m_what); pstr) {
+		return *pstr;
+	}
+
+	assert(false);
+	__builtin_unreachable();
+}
+
+Exception Exception::fromError(std::error_condition error, const char *what, Location loc) noexcept
+{
+	return { what ? what : "see stored error condition", error, loc };
+}
+
+Exception Exception::fromFailedCall(std::error_condition error, std::string_view api, Location loc)
+{
+	assert(api.length() > 0);
+	return { fmt::format("call to '{}' failed", api), error, loc };
+}
+
+Exception::Exception(std::variant<const char *, std::string> what, std::error_condition error, Location loc) noexcept
+	: m_what(std::move(what)), m_error(error), m_where(loc)
+{
+	// TODO: this is the best place to capture stacktrace
 }
 
 }

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -21,28 +21,6 @@ const char *MessageException::what() const noexcept
 	return m_what;
 }
 
-FormattedMessageException::FormattedMessageException(std::string_view format_str, const fmt::format_args &format_args,
-	extras::source_location loc) noexcept : Exception(loc)
-{
-	try {
-		m_what = fmt::vformat(format_str, format_args);
-	} catch (...) {
-		m_exception_occured = true;
-	}
-}
-
-const char *FormattedMessageException::what() const noexcept
-{
-	constexpr static char EXCEPTION_OCCURED_MSG[] =
-		"Exception occured during creating FormattedMessageException, message is lost";
-
-	if (m_exception_occured) {
-		return EXCEPTION_OCCURED_MSG;
-	}
-
-	return m_what.c_str();
-}
-
 ErrnoException::ErrnoException(int code, const char *api, extras::source_location loc) noexcept
 	: Exception(loc), m_code(code)
 {


### PR DESCRIPTION
Exceptions now carry error condition and do not support rich formatted explanatory messages. The reasoning is that messages can't be tested and reacted on, so it's better to just log them at error sites. Error codes can, so catch clauses can become a bit smarter with this change.

- Significant rework of `Exception` class (see above)
- Remove `MessageException`, `FormattedMessageException` and `ErrnoException`
- Stripped unused `source_location` fields (function name and column)
- Improved `getVk*String` (use `string_view`, less code, compile-time protection by `-Wswitch`)
- Make `VkResult` eligible for `std::error_condition` (which it is)
- Removed some improper uses of exceptions (where asserts or other means should be used)
- Added Voxen-specific error enum (also eligible for `std::error_condition`)