### PR TITLE
Conversion to libvoxen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,23 +25,27 @@ add_subdirectory(3rdparty)
 
 # CMake target setup
 voxen_add_library(extras STATIC)
-voxen_add_executable(voxen)
+voxen_add_library(voxen SHARED)
+voxen_add_executable(game)
 
-target_compile_definitions(voxen PRIVATE VOXEN_DEBUG_BUILD=$<CONFIG:Debug>)
+target_compile_definitions(voxen PUBLIC VOXEN_DEBUG_BUILD=$<CONFIG:Debug>)
 
 find_package(Threads REQUIRED)
-target_link_libraries(voxen PRIVATE
+target_link_libraries(voxen PUBLIC
 	extras
 	3rdparty::cxxopts
 	3rdparty::fmt
-	3rdparty::glfw
 	3rdparty::glm
-	3rdparty::platform-folders
 	3rdparty::simpleini
-	3rdparty::vulkan-headers
-	3rdparty::zlib
 	Threads::Threads
 )
+target_link_libraries(voxen PRIVATE
+	3rdparty::glfw
+	3rdparty::platform-folders
+	3rdparty::vulkan-headers
+	3rdparty::zlib
+)
+target_link_libraries(game PRIVATE voxen)
 
 include(include/CMakeLists.txt)
 include(src/CMakeLists.txt)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -91,6 +91,7 @@ set(VOXEN_HEADERS
 	include/voxen/util/hash.hpp
 	include/voxen/util/log.hpp
 	include/voxen/util/resolution.hpp
+	include/voxen/visibility.hpp
 )
 
 target_include_directories(voxen PRIVATE include)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -94,7 +94,7 @@ set(VOXEN_HEADERS
 	include/voxen/visibility.hpp
 )
 
-target_include_directories(voxen PRIVATE include)
+target_include_directories(voxen PUBLIC include)
 target_sources(voxen PRIVATE ${VOXEN_HEADERS})
 source_group(TREE ${CMAKE_SOURCE_DIR}/include/voxen PREFIX Headers FILES ${VOXEN_HEADERS})
 

--- a/include/voxen/client/gui.hpp
+++ b/include/voxen/client/gui.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
+#include <voxen/client/window.hpp>
 #include <voxen/common/gameview.hpp>
 #include <voxen/common/world_state.hpp>
-#include <voxen/client/window.hpp>
+#include <voxen/visibility.hpp>
 
 struct GLFWwindow;
 
 namespace voxen::client
 {
 
-class Gui {
+class VOXEN_API Gui {
 public:
 	Gui(Window& window);
 	~Gui() noexcept;

--- a/include/voxen/client/render.hpp
+++ b/include/voxen/client/render.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <voxen/client/window.hpp>
-
 #include <voxen/common/world_state.hpp>
 #include <voxen/common/gameview.hpp>
+#include <voxen/visibility.hpp>
 
 namespace voxen::client
 {
 
-class Render {
+class VOXEN_API Render {
 public:
 	explicit Render(Window &window);
 	Render(Render &&) = delete;

--- a/include/voxen/client/vulkan/common.hpp
+++ b/include/voxen/client/vulkan/common.hpp
@@ -40,7 +40,7 @@ public:
 	static uint64_t calcFraction(uint64_t size, uint64_t numerator, uint64_t denomenator) noexcept;
 };
 
-class VulkanException final : public Exception {
+class VOXEN_API VulkanException final : public Exception {
 public:
 	explicit VulkanException(VkResult result, std::string_view api, extras::source_location loc =
 		extras::source_location::current());

--- a/include/voxen/client/window.hpp
+++ b/include/voxen/client/window.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <voxen/visibility.hpp>
+
 #include <cstdint>
 #include <utility>
 
@@ -12,7 +14,7 @@ namespace voxen::client
 
 class Gui;
 
-class Window {
+class VOXEN_API Window {
 public:
 	bool shouldClose() const;
 	void pollEvents();
@@ -52,15 +54,14 @@ private:
 	GLFWwindow *mWindow;
 	Gui* m_attached_gui = nullptr;
 
-	void logGlfwVersion() const;
-	void createWindow(int width, int height);
+	VOXEN_LOCAL void createWindow(int width, int height);
 
-	static void globalKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) noexcept;
-	static void globalMouseMovement(GLFWwindow* window, double xpos, double ypos) noexcept;
-	static void globalMouseKey(GLFWwindow* window, int button, int action, int mods) noexcept;
-	static void globalMouseScroll(GLFWwindow* window, double xoffset, double yoffset) noexcept;
+	VOXEN_LOCAL static void globalKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) noexcept;
+	VOXEN_LOCAL static void globalMouseMovement(GLFWwindow* window, double xpos, double ypos) noexcept;
+	VOXEN_LOCAL static void globalMouseKey(GLFWwindow* window, int button, int action, int mods) noexcept;
+	VOXEN_LOCAL static void globalMouseScroll(GLFWwindow* window, double xoffset, double yoffset) noexcept;
 
-	static void glfwErrorCallback(int code, const char *message) noexcept;
+	VOXEN_LOCAL static void glfwErrorCallback(int code, const char *message) noexcept;
 };
 
 }

--- a/include/voxen/common/config.hpp
+++ b/include/voxen/common/config.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <voxen/visibility.hpp>
+
 #include <extras/source_location.hpp>
 
 #include <filesystem>
@@ -16,7 +18,7 @@
 namespace voxen
 {
 
-class Config {
+class VOXEN_API Config {
 public:
 	using Location = extras::source_location;
 	using option_t = std::variant<std::string, int64_t, double, bool>;

--- a/include/voxen/common/filemanager.hpp
+++ b/include/voxen/common/filemanager.hpp
@@ -1,16 +1,18 @@
 #pragma once
 
+#include <voxen/visibility.hpp>
+
+#include <extras/dyn_array.hpp>
+
 #include <cstring>
 #include <optional>
 #include <future>
 #include <filesystem>
 
-#include <extras/dyn_array.hpp>
-
 namespace voxen
 {
 
-class FileManager {
+class VOXEN_API FileManager {
 public:
 	static void setProfileName(const std::string &path_to_binary, const std::string &profile_name = "default");
 

--- a/include/voxen/common/threadpool.hpp
+++ b/include/voxen/common/threadpool.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <voxen/visibility.hpp>
+
 #include <mutex>
 #include <queue>
 #include <memory>
@@ -54,7 +56,7 @@ private:
 	std::mutex m_mutex;
 };
 
-class ThreadPool {
+class VOXEN_API ThreadPool {
 public:
 	enum class TaskType {
 		// This is a CPU-bound task without particular timing restrictions

--- a/include/voxen/server/world.hpp
+++ b/include/voxen/server/world.hpp
@@ -2,6 +2,7 @@
 
 #include <voxen/common/terrain/controller.hpp>
 #include <voxen/common/world_state.hpp>
+#include <voxen/visibility.hpp>
 
 #include <memory>
 #include <mutex>
@@ -9,7 +10,7 @@
 namespace voxen::server
 {
 
-class World {
+class VOXEN_API World {
 public:
 	World();
 	World(World &&) = delete;

--- a/include/voxen/util/exception.hpp
+++ b/include/voxen/util/exception.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <voxen/visibility.hpp>
+
 #include <extras/source_location.hpp>
 
 #include <exception>
@@ -11,7 +13,7 @@
 namespace voxen
 {
 
-class Exception : public std::exception {
+class VOXEN_API Exception : public std::exception {
 public:
 	using Location = extras::source_location;
 

--- a/include/voxen/util/log.hpp
+++ b/include/voxen/util/log.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <voxen/config.hpp>
+#include <voxen/visibility.hpp>
 
 #include <extras/enum_utils.hpp>
 #include <extras/source_location.hpp>
@@ -10,7 +11,7 @@
 namespace voxen
 {
 
-class Log {
+class VOXEN_API Log {
 public:
 	enum class Level : int {
 		/* Information about implementation details of some specific action (e.g. values of variables on each

--- a/include/voxen/visibility.hpp
+++ b/include/voxen/visibility.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+// Denotes public symbol (exported from shared library)
+#define VOXEN_API __attribute__((visibility("default")))
+
+// Denotes private symbol (not visible outside shared library)
+#define VOXEN_LOCAL __attribute__((visibility("hidden")))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,9 @@ set(VOXEN_SOURCES
 	src/util/exception.cpp
 	src/util/hash.cpp
 	src/util/log.cpp
+)
+
+target_sources(game PRIVATE
 	src/main.cpp
 )
 

--- a/src/client/window.cpp
+++ b/src/client/window.cpp
@@ -10,13 +10,23 @@ namespace voxen::client
 
 Window Window::gInstance;
 
+static void logGlfwVersion()
+{
+	Log::debug("Voxen is compiled against GLFW {}.{}.{} ({})",
+		GLFW_VERSION_MAJOR, GLFW_VERSION_MINOR, GLFW_VERSION_REVISION, glfwGetVersionString());
+
+	int major, minor, revision;
+	glfwGetVersion(&major, &minor, &revision);
+	Log::debug("Voxen is running against GLFW {}.{}.{}", major, minor, revision);
+}
+
 void Window::start(int width, int height)
 {
 	if (mIsStarted) {
 		return;
 	}
 	Log::info("Starting window and GLFW library");
-	logGlfwVersion ();
+	logGlfwVersion();
 	glfwSetErrorCallback (&Window::glfwErrorCallback);
 	if (glfwInit () != GLFW_TRUE) {
 		Log::fatal("Couldn't init GLFW!");
@@ -48,15 +58,6 @@ bool Window::shouldClose() const
 void Window::pollEvents()
 {
 	glfwPollEvents ();
-}
-
-void Window::logGlfwVersion() const
-{
-	Log::debug("Voxen is compiled against GLFW {}.{}.{} ({})",
-		GLFW_VERSION_MAJOR, GLFW_VERSION_MINOR, GLFW_VERSION_REVISION, glfwGetVersionString ());
-	int major, minor, revision;
-	glfwGetVersion (&major, &minor, &revision);
-	Log::debug("Voxen is running against GLFW {}.{}.{}", major, minor, revision);
 }
 
 void Window::createWindow(int width, int height)


### PR DESCRIPTION
There are going to be multiple executables using engine - the game itself, test runners, development tools, feature experiments, SDK etc. Packing the engine into a separate shared library looks logical.

- Improved toolchain parameters:
  - Use prefix map for debug info too
  - Enable PIC/PIE for all targets
  - More potentially-obscurely-breaking optimization flags
- Introduced `VOXEN_API`/`VOXEN_LOCAL` macros for visibility control
- Marked certain parts with these macros (exceptions and classes used by current `main.cpp`)
- Split most of the code into a shared library (`libvoxen.so`), leaving only `main.cpp` in executable (now called `game`)