### PR TITLE
Better logs

### DIFF
--- a/include/voxen/util/log.hpp
+++ b/include/voxen/util/log.hpp
@@ -12,6 +12,7 @@ namespace voxen
 
 class VOXEN_API Log {
 public:
+	// Log levels are defined by increasing severity - it's valid to compare them as integers
 	enum class Level : int {
 		/* Information about implementation details of some specific action (e.g. values of variables on each
 		 * iteration of a loop in some algorithm). There should generally be no logging of this level in the

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -1,7 +1,10 @@
 #include <voxen/util/log.hpp>
 
+#include <fmt/chrono.h>
 #include <fmt/color.h>
 #include <fmt/format.h>
+
+#include <unistd.h>
 
 #include <cassert>
 #include <cstdio>
@@ -11,6 +14,8 @@ namespace voxen
 
 Log::Level Log::m_current_level = Log::Level::Trace;
 
+// Thread-local "waterline cache" buffer to avoid allocations on each print.
+// FMT can still do temporary internal allocations but we can't control that.
 static thread_local fmt::memory_buffer t_message_buffer;
 
 static fmt::text_style styleForLevel(Log::Level level) noexcept
@@ -47,37 +52,66 @@ static fmt::text_style styleForLevel(Log::Level level) noexcept
 void Log::doLog(Level level, extras::source_location where,
                 std::string_view format_str, fmt::format_args format_args) noexcept
 {
-	try {
-		t_message_buffer.clear();
-		fmt::vformat_to(std::back_inserter(t_message_buffer), format_str, format_args);
-		std::string_view text(t_message_buffer.data(), t_message_buffer.size());
+	// Prepare formatted text (or failure message) to be logged
+	std::string_view text;
 
+	try {
+		auto &msgbuf = t_message_buffer;
+
+		try {
+			msgbuf.clear();
+			fmt::vformat_to(std::back_inserter(msgbuf), format_str, format_args);
+		} catch (const fmt::format_error &err) { // This is the only practically expected error
+			level = std::max(level, Level::Error); // Raise log level to at least Error
+			msgbuf.clear(); // Clear the buffer, it could be partially filled by try-code
+			fmt::format_to(std::back_inserter(msgbuf), "Caught fmt::format_error when trying to log: {}", err.what());
+		} catch (const std::bad_alloc &err) {
+			level = std::max(level, Level::Error); // Raise log level to at least Error
+			msgbuf.clear(); // Clear the buffer, it could be partially filled by try-code
+			// `msgbuf` is large enough to fit this error string inline without hitting `bad_alloc` again
+			fmt::format_to(std::back_inserter(msgbuf), "Caught std::bad_alloc when trying to log: {}", err.what());
+		}
+
+		text = {msgbuf.data(), msgbuf.size()};
+	} catch (...) {
+		// Getting here means failure in catch clauses or an "unexpected" exception.
+		// We can't do anything potentially-throwing here so just use a literal.
+		level = std::max(level, Level::Error); // Raise log level to at least Error
+		text = "Caught [unknown exception] when trying to log";
+	}
+
+	// Now try to print this text
+	const auto pid = getpid();
+	const auto tid = gettid();
+
+	try {
+		// Select the sink (stdout for `X <= Info`, stderr for `X >= Warn`)
 		FILE *sink = stdout;
 		if (level >= Level::Warn) {
 			// Flush `stdout` to not mess the messages when it's directed to same output as `stderr`
+			// TODO (Svenny): check if `stdout` and `stderr` target different outputs?
 			fflush(stdout);
 			sink = stderr;
 		}
 
-		fmt::print(sink, FMT_STRING("[{:s}:{:d}][{:s}] {:s}\n"),
+		fmt::print(sink, "[{:%F %T}][{} {}][{:s}:{:d}][{:s}] {:s}\n",
+		           std::chrono::system_clock::now(), pid, tid,
 		           where.file_name(), where.line(),
 		           fmt::styled(extras::enum_name(level), styleForLevel(level)), text);
-	} catch (const fmt::format_error &err) {
+	} catch (const std::system_error &err) {
+		// Reaching this clause means printing to `sink` failed for system reasons (bad file?).
+		// Retrying here is probably useless if `sink` was `stderr` but might work for `stdout`.
 		fflush(stdout);
-		fprintf(stderr, "[%s:%u][WARN] Caught fmt::format_error when trying to log: %s\n",
-		        where.file_name(), where.line(), err.what());
-	} catch (const std::bad_alloc &err) {
-		fflush(stdout);
-		fprintf(stderr, "[%s:%u][WARN] Caught std::bad_alloc when trying to log: %s\n",
-		        where.file_name(), where.line(), err.what());
-	} catch (const std::exception &err) {
-		fflush(stdout);
-		fprintf(stderr, "[%s:%u][WARN] Caught std::exception when trying to log: %s\n",
-		        where.file_name(), where.line(), err.what());
+		// TODO (Svenny): date/time can be printed here too but I'm too lazy to implement it
+		fprintf(stderr, "[XXXX-XX-XX XX:XX:XX][%d %d][%s:%u][ERROR] std::system_error when printing log: %s:%d (%s)\n",
+		        pid, tid, where.file_name(), where.line(),
+		        err.code().category().name(), err.code().value(), err.what());
 	} catch (...) {
+		// Reaching this clause means something is deeply broken... but try one last time
 		fflush(stdout);
-		fprintf(stderr, "[%s:%u][WARN] Caught unknown exception when trying to log\n",
-		        where.file_name(), where.line());
+		// TODO (Svenny): date/time can be printed here too but I'm too lazy to implement it
+		fprintf(stderr, "[XXXX-XX-XX XX:XX:XX][%d %d][%s:%u][ERROR] Unknown exception when printing log!\n",
+		        pid, tid, where.file_name(), where.line());
 	}
 }
 


### PR DESCRIPTION
- Colored `Log` outputs to console
- Added date/time and PID/TID to messages, making the log fully packed with information
- Slightly reworked log-internal error-related logic
- Updated FMT from 9.0.0 to 9.1.0